### PR TITLE
[BUGFIX] Require PHP 7.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
   "type": "typo3-cms-extension",
   "license": "GPL-3.0",
   "require": {
-    "php": "^7.2",
+    "php": "^7.4",
     "typo3/cms-core": "^10.4 || ^11.4"
   },
   "autoload": {


### PR DESCRIPTION
The current code basis requires PHP 7.4 (typed properties
in classes are used).

The composer version should be corrected.