### PR TITLE
[BUGFIX] Order categories by title in flexforms

### DIFF
--- a/Configuration/FlexForms/FlexFormPi4.xml
+++ b/Configuration/FlexForms/FlexFormPi4.xml
@@ -23,7 +23,7 @@
 								<minitems>0</minitems>
 								<maxitems>100</maxitems>
 								<foreign_table>tx_in2faq_domain_model_category</foreign_table>
-								<foreign_table_where>AND tx_in2faq_domain_model_category.deleted = 0 AND tx_in2faq_domain_model_category.hidden = 0 order by tx_in2faq_domain_model_category.sorting asc</foreign_table_where>
+								<foreign_table_where>AND tx_in2faq_domain_model_category.deleted = 0 AND tx_in2faq_domain_model_category.hidden = 0 order by tx_in2faq_domain_model_category.title asc</foreign_table_where>
 							</config>
 						</TCEforms>
 					</settings.flexform.main.categories>


### PR DESCRIPTION
Since the sorting field is gone for categories, the flexforms should still output valid entries.