### PR TITLE
[BUGFIX] Add missing spread operator in query logicalOr method call

### DIFF
--- a/Classes/Domain/Repository/QuestionRepository.php
+++ b/Classes/Domain/Repository/QuestionRepository.php
@@ -66,7 +66,7 @@ class QuestionRepository extends AbstractRepository
             foreach ($categoryUids as $categoryUid) {
                 $logicalOr[] = $query->equals('categories.uid', (int)$categoryUid);
             }
-            $and[] = $query->logicalOr($logicalOr);
+            $and[] = $query->logicalOr(...$logicalOr);
         }
         return $and;
     }


### PR DESCRIPTION
While upgrading the extension to version 12 a missing spread operator has probably been missed to add to the method `logicalOr` of the query, filtering for categories - `filterBySettingsCategories`.
(The later method in the `QuestionRepository` class already has the spread operator added in the method call of `logicalOr` - `filterByFilterSearchterm`.)

Changelog for Typo3 v12: https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/12.0/Breaking-96044-HardenMethodSignatureOfLogicalAndAndLogicalOr.html